### PR TITLE
fix(linebreak): allow Knuth-Plass to place words longer than width

### DIFF
--- a/pkg/linebreak/knuthplass.go
+++ b/pkg/linebreak/knuthplass.go
@@ -38,7 +38,7 @@ func KnuthPlass(text string, width int) []string {
 			spaces := j - i - 1
 			totalLen := lineLength + spaces
 
-			if totalLen > width {
+			if totalLen > width && j > i+1 {
 				break
 			}
 

--- a/test/linebreak/knuthplass_test.go
+++ b/test/linebreak/knuthplass_test.go
@@ -67,6 +67,14 @@ func TestKnuthPlass(t *testing.T) {
 				expected: []string{"The lazy", "yellow dog", "was caught by", "the slow red", "fox as he lay", "sleeping in", "the sun"},
 			},
 		},
+		{
+			name: "Word longer than width",
+			args: args{
+				text:     "a supercalifragilisticexpialidocious word",
+				width:    10,
+				expected: []string{"a", "supercalifragilisticexpialidocious", "word"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- A word longer than the target width could never get a finite cost in the Knuth-Plass DP, leaving `minCost` stuck at `+Inf` and collapsing the entire input onto a single line instead of wrapping.
- Fixed by always allowing a single-word line (`j == i+1`) to be costed even when it overflows the width, matching `Greedy`'s existing behavior of never dropping an overlong word.

## Test plan
- [x] Added `Word longer than width` case to `TestKnuthPlass`
- [x] `go test ./...` passes